### PR TITLE
Add instructions to apply Canary on Linux Wayland

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,25 +14,20 @@ Double click on the dmg file you downloaded and follow the directions.
 ## Linux
 [Click here to download the Linux XKB file.](https://github.com/Apsu/Canary/releases/download/v1.0/canary)
 
-Open a terminal. Run `sudo mv Downloads/canary /usr/share/X11/xkb/symbols`. Now you can run `setxkbmap canary` to set your current layout
-to Canary.
+After that, move the file to the `/usr/share/X11/xkb/symbols` directory. You can use the following command to achieve the same.
+```bash
+sudo mv Downloads/canary /usr/share/X11/xkb/symbols`
+```
 
-### Note
+Now you can run `setxkbmap canary` to set your current layout to Canary.
 
-In Wayland, the approach to adding custom keyboard layouts differs from X11. You can't directly use `setxkbmap` since it's specific to X11. Instead, you’ll need to add your custom layout to the appropriate directory and use different methods to apply it.
+> [!Note]
+>In Wayland, the approach to adding custom keyboard layouts differs from X11. You can't directly use `setxkbmap` since it's specific to X11. Instead, you’ll need to add your custom layout to the appropriate directory and use different methods to apply it.
 
-Here’s how you can set up a custom layout in Wayland:
-
-1. **Copy the Layout File:**
-   You can still move your custom layout file to the appropriate directory:
-   ```bash
-   sudo mv ~/Downloads/canary /usr/share/X11/xkb/symbols/
-   ```
-
-2. **Update the XKB Configuration:**
+1. **Update the XKB Configuration:**
    Since Wayland uses the XKB system but doesn't rely on `setxkbmap`, you typically need to ensure your custom layout is recognized by the system. You may also want to check if you need to modify files like `/usr/share/X11/xkb/rules/evdev.xml` or `evdev.lst` to reference your new layout.
 
-3. **Use `localectl` or Desktop Environment Settings:**
+2. **Use `localectl` or Desktop Environment Settings:**
    Once your custom layout is in place, use `localectl` to set it:
    ```bash
    localectl set-x11-keymap canary
@@ -40,7 +35,7 @@ Here’s how you can set up a custom layout in Wayland:
 
    Alternatively, you can change the layout via your desktop environment settings, as mentioned earlier.
 
-4. **Log Out and Log Back In:**
+3. **Log Out and Log Back In:**
    Sometimes, you may need to log out of your session and back in for the changes to take effect.
 
 This way, you can effectively use your custom keyboard layout in a Wayland environment.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,3 +16,31 @@ Double click on the dmg file you downloaded and follow the directions.
 
 Open a terminal. Run `sudo mv Downloads/canary /usr/share/X11/xkb/symbols`. Now you can run `setxkbmap canary` to set your current layout
 to Canary.
+
+### Note
+
+In Wayland, the approach to adding custom keyboard layouts differs from X11. You can't directly use `setxkbmap` since it's specific to X11. Instead, you’ll need to add your custom layout to the appropriate directory and use different methods to apply it.
+
+Here’s how you can set up a custom layout in Wayland:
+
+1. **Copy the Layout File:**
+   You can still move your custom layout file to the appropriate directory:
+   ```bash
+   sudo mv ~/Downloads/canary /usr/share/X11/xkb/symbols/
+   ```
+
+2. **Update the XKB Configuration:**
+   Since Wayland uses the XKB system but doesn't rely on `setxkbmap`, you typically need to ensure your custom layout is recognized by the system. You may also want to check if you need to modify files like `/usr/share/X11/xkb/rules/evdev.xml` or `evdev.lst` to reference your new layout.
+
+3. **Use `localectl` or Desktop Environment Settings:**
+   Once your custom layout is in place, use `localectl` to set it:
+   ```bash
+   localectl set-x11-keymap canary
+   ```
+
+   Alternatively, you can change the layout via your desktop environment settings, as mentioned earlier.
+
+4. **Log Out and Log Back In:**
+   Sometimes, you may need to log out of your session and back in for the changes to take effect.
+
+This way, you can effectively use your custom keyboard layout in a Wayland environment.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,31 +11,24 @@ good idea but might not be necessary.
 
 Double click on the dmg file you downloaded and follow the directions.
 
-## Linux
-[Click here to download the Linux XKB file.](https://github.com/Apsu/Canary/releases/download/v1.0/canary)
+## Linux  
+[Click here to download the Linux XKB file.](https://github.com/Apsu/Canary/releases/download/v1.0/canary)  
 
-After that, move the file to the `/usr/share/X11/xkb/symbols` directory. You can use the following command to achieve the same.
+Move the file to the `/usr/share/X11/xkb/symbols` directory. You can do this by opening a terminal and running:  
 ```bash
-sudo mv Downloads/canary /usr/share/X11/xkb/symbols`
-```
+sudo mv Downloads/canary /usr/share/X11/xkb/symbols
+```  
 
-Now you can run `setxkbmap canary` to set your current layout to Canary.
+To use the layout, run the following command:  
+```bash
+setxkbmap canary
+```  
 
-> [!Note]
->In Wayland, the approach to adding custom keyboard layouts differs from X11. You can't directly use `setxkbmap` since it's specific to X11. Instead, you’ll need to add your custom layout to the appropriate directory and use different methods to apply it.
+If you are using Wayland, `setxkbmap` won't work directly. Instead, you need to add the layout manually and apply it using `localectl` or your desktop environment settings. You may also need to modify `/usr/share/X11/xkb/rules/evdev.xml` or `evdev.lst` to make the system recognize the layout.  
 
-1. **Update the XKB Configuration:**
-   Since Wayland uses the XKB system but doesn't rely on `setxkbmap`, you typically need to ensure your custom layout is recognized by the system. You may also want to check if you need to modify files like `/usr/share/X11/xkb/rules/evdev.xml` or `evdev.lst` to reference your new layout.
+To apply the layout using `localectl`, run:  
+```bash
+localectl set-x11-keymap canary
+```  
 
-2. **Use `localectl` or Desktop Environment Settings:**
-   Once your custom layout is in place, use `localectl` to set it:
-   ```bash
-   localectl set-x11-keymap canary
-   ```
-
-   Alternatively, you can change the layout via your desktop environment settings, as mentioned earlier.
-
-3. **Log Out and Log Back In:**
-   Sometimes, you may need to log out of your session and back in for the changes to take effect.
-
-This way, you can effectively use your custom keyboard layout in a Wayland environment.
+After making these changes, logging out and back in might be necessary for the layout to take effect.


### PR DESCRIPTION
On Linux compositors using Wayland, the `setxkbmap canary` command returns

> `WARNING: Running setxkbmap against an Xwayland server`

On KDE Plasma this is solved by using the `localectl` command.